### PR TITLE
Fix bug when inlining all environment variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,6 @@ var compose = require('fn-compose');
 
 // make sure replacements is an array
 function ensureReplacementsIsArray(replacements) {
-  if (typeof replacements === 'undefined') {
-    return [process.env];
-  }
-
   if (replacements.constructor !== Array) {
     return [replacements];
   }
@@ -34,11 +30,16 @@ function mergeReplacements(replacements) {
 
 // compose all above actions into a single function
 function normalizeReplacements(replacements) {
+  var finalReplacements = replacements;
+  if (typeof replacements === 'undefined') {
+    finalReplacements = [process.env];
+  }
+
   return compose(
     mergeReplacements,
     convertAllReplacementsToObject,
     ensureReplacementsIsArray
-  )(replacements);
+  )(finalReplacements);
 }
 
 // warn if you are trying to inline a env var that is not defined


### PR DESCRIPTION
When trying to instantiate this plugin without passing any config, it errors `TypeError: Cannot convert undefined or null to object` at [this line](https://github.com/goodeggs/inline-environment-variables-webpack-plugin/blob/master/index.js#L53)

This is because the `fn-compose` module uses `maybe-args` which [returns undefined without calling the function if the argument is falsy](https://github.com/thunklife/maybe-args/blob/master/index.js#L9-L13).

This fixes the issue by defaulting `replacements = [process.env]` before calling the composed method.
